### PR TITLE
Fixed newline typo at the begining of animation's doc

### DIFF
--- a/src/tiramisu/animation.gleam
+++ b/src/tiramisu/animation.gleam
@@ -76,7 +76,8 @@
 ////     callback,
 ////     { once: true }
 ////   )
-//// </script>//// Tiramisu game engine main module - immutable game loop with effect system.
+//// </script>
+//// Tiramisu game engine main module - immutable game loop with effect system.
 ////
 //// Animation and tweening system for smooth transitions and Three.js model animations.
 ////


### PR DESCRIPTION
Currently its look like this:

<img width="777" height="296" alt="image" src="https://github.com/user-attachments/assets/2d438697-579b-4c53-b02e-4544c47d1924" />
